### PR TITLE
Fix secondary clicks not activating button styles

### DIFF
--- a/edsy.css
+++ b/edsy.css
@@ -2044,7 +2044,8 @@ BODY.onlybest.experimental #outfitting_modules.SLOT #outfitting_modules_picker.s
 	color: var(--colororange5);
 	font: var(--fontfixed);
 }
-#outfitting_fit_slots BUTTON.outfitting_fit_priority:active {
+#outfitting_fit_slots BUTTON.outfitting_fit_priority:active,
+#outfitting_fit_slots BUTTON.outfitting_fit_priority.right-click-active {
 	background-color: transparent !important;
 	color: var(--colorwhite) !important;
 }
@@ -2064,7 +2065,8 @@ BODY.onlybest.experimental #outfitting_modules.SLOT #outfitting_modules_picker.s
 	border-left: none;
 	border-right-color: var(--colororange3);
 }
-#outfitting_fit_slots BUTTON.outfitting_fit_priority:active::before {
+#outfitting_fit_slots BUTTON.outfitting_fit_priority:active::before,
+#outfitting_fit_slots BUTTON.outfitting_fit_priority.right-click-active::before {
 	border-right-color: var(--colorwhite) !important;
 }
 #outfitting_fit_slots BUTTON.outfitting_fit_priority::after {
@@ -2072,7 +2074,8 @@ BODY.onlybest.experimental #outfitting_modules.SLOT #outfitting_modules_picker.s
 	border-right: none;
 	border-left-color: var(--colororange3);
 }
-#outfitting_fit_slots BUTTON.outfitting_fit_priority:active::after {
+#outfitting_fit_slots BUTTON.outfitting_fit_priority:active::after,
+#outfitting_fit_slots BUTTON.outfitting_fit_priority.right-click-active::after {
 	border-left-color: var(--colorwhite) !important;
 }
 #outfitting_fit_slots BUTTON.outfitting_fit_priority:disabled {

--- a/edsy.js
+++ b/edsy.js
@@ -613,6 +613,7 @@ window.edsy = new (function() {
 		// no matter what.
 		if (window.secondaryActiveButton) {
 			window.secondaryActiveButton.classList.remove('right-click-active');
+			window.secondaryActiveButton = null;
 		}
 	}; // clearSecondaryActiveMouseUp()
 


### PR DESCRIPTION
Workaround for :active pseudo-selector not being applied to right-click events. Per the CSS spec, only holding down the primary mouse button should apply the :active pseudo-selector. Our workaround is to wrap the mouse down event with the code below. It'll find the button being pressed and add an active CSS class that we can use in our CSS.

See: https://bugs.chromium.org/p/chromium/issues/detail?id=966255